### PR TITLE
Catch null head components

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -4,7 +4,7 @@ import React from "react";
 export const onPreRenderHTML = ({ getHeadComponents, replaceHeadComponents }, pluginOptions) => {
     if (process.env.NODE_ENV === `production` || pluginOptions.includeInDevelopment) {
         let headComponents = getHeadComponents();
-        let scripts = headComponents.filter((el) => el.type === "script");
+        let scripts = headComponents.filter((el) => el && el.type === "script");
         const osano = scripts.find((el) => el.key === "gatsby-plugin-osano");
         scripts = scripts.filter((el) => el !== osano);
         headComponents = headComponents.filter((el) => el.type !== "script");


### PR DESCRIPTION
While filtering you could get a case where the element is null.
This adds an extra check to ensure the element is valid before checking its type.

```
error There was an error compiling the html.js component for the development server.
See our docs page on debugging HTML builds for help https://gatsby.dev/debug-html TypeError: Cannot read property 'type' of null
  18 |     var headComponents = getHeadComponents();
  19 |     var scripts = headComponents.filter(function (el) {
> 20 |       return el.type === "script";
     |                 ^
  21 |     });
  22 |     var osano = scripts.find(function (el) {
  23 |       return el.key === "gatsby-plugin-osano";
  WebpackError: TypeError: Cannot read property 'type' of null
  - gatsby-ssr.js:20 
    node_modules/gatsby-plugin-osano/gatsby-ssr.js:20:17
  - gatsby-ssr.js:19 
    node_modules/gatsby-plugin-osano/gatsby-ssr.js:19:34
```