### PR TITLE
Additionally catch null non-script head components

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -7,7 +7,7 @@ export const onPreRenderHTML = ({ getHeadComponents, replaceHeadComponents }, pl
         let scripts = headComponents.filter((el) => el && el.type === "script");
         const osano = scripts.find((el) => el.key === "gatsby-plugin-osano");
         scripts = scripts.filter((el) => el !== osano);
-        headComponents = headComponents.filter((el) => el.type !== "script");
+        headComponents = headComponents.filter((el) => el && el.type !== "script");
         scripts.unshift(osano);
         headComponents = headComponents.concat(scripts);
 


### PR DESCRIPTION
Previously i did this for scripts, but forgot to do this for the 2nd part where we combine them back together again.
This is my mistake for not totally understand the entire flow before submitting the change. Apologies.